### PR TITLE
Update async_tile_fetcher.py

### DIFF
--- a/async_tile_fetcher.py
+++ b/async_tile_fetcher.py
@@ -17,6 +17,12 @@ def exponential_backoff(f, n=5, err=Exception):
 
 @exponential_backoff
 async def fetch(session, url, destination):
+    """
+    'aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host lh3.googleusercontent.com:443 ssl:default'
+    If this error occurs, use the 'http' to get
+    """
+    url = url.replace("https", "http")
+    
     if destination.is_file():
         return destination.read_bytes()
     async with session.get(url) as response:

--- a/tile_fetch.py
+++ b/tile_fetch.py
@@ -40,7 +40,16 @@ class ImageInfo(object):
     RE_URL_PATH_TOKEN = re.compile(rb']\n,"(//[^"/]+/([^"/]+))",(?:"([^"]+)"|null)', re.MULTILINE)
 
     def __init__(self, url):
-        page_source = urllib.request.urlopen(url).read()
+        httpproxy_handler = urllib.request.ProxyHandler(
+            {
+                "http" : "http://127.0.0.1:1080",
+                "https": "http://127.0.0.1:1080"
+            },
+        )
+        
+        opener = urllib.request.build_opener(httpproxy_handler)
+        
+        page_source = opener.open(url).read()
 
         match = self.RE_URL_PATH_TOKEN.search(page_source)
         if match is None:
@@ -52,7 +61,7 @@ class ImageInfo(object):
         self.image_name = '%s - %s' % (string.capwords(self.image_slug.replace("-"," ")), image_id)
 
         meta_info_url = "https:{}=g".format(url_no_proto.decode('utf8'))
-        meta_info_tree = etree.fromstring(urllib.request.urlopen(meta_info_url).read())
+        meta_info_tree = etree.fromstring(opener.open(meta_info_url).read())
         self.tile_width = int(meta_info_tree.attrib['tile_width'])
         self.tile_height = int(meta_info_tree.attrib['tile_height'])
         self.tile_info = [


### PR DESCRIPTION
fix the error:
> aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host lh3.googleusercontent.com:443 ssl:default

```
Traceback (most recent call last):
  File "D:\Projects\google art\async_tile_fetcher.py", line 8, in modified
    return await f(*args, **kwargs)
  File "D:\Projects\google art\async_tile_fetcher.py", line 24, in fetch
    async with session.get(url) as response:
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\client.py", line 1012, in __aenter__
    self._resp = await self._coro
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\client.py", line 480, in _request
    conn = await self._connector.connect(
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\connector.py", line 523, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\connector.py", line 855, in _create_connection
    _, proto = await self._create_proxy_connection(
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\connector.py", line 1093, in _create_proxy_connection
    transport, proto = await self._wrap_create_connection(
  File "C:\Users\xx\AppData\Local\Programs\Python\Python38-32\lib\site-packages\aiohttp\connector.py", line 943, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host lh3.googleusercontent.com:443 ssl:default
```